### PR TITLE
C shorter TSS paths: /v1/organizations/:oid => /v1/:oid

### DIFF
--- a/lib/tss/connector.rb
+++ b/lib/tss/connector.rb
@@ -16,19 +16,16 @@ module TSS
 
     # @raise [RuntimeError] TSS request failed
     def get_organization # rubocop:disable AccessorMethodName
-      path = "/v1/organizations/#{oid}"
+      path = base_path
       response = HttpRetriever.authenticated_get(path)
-
       handle_get_response(response, path, 'organization')
     end
 
-    # @param organization_id [String] UUID format.
     # @param meta [Hash<String,Object>] JSON serializable dictionary.
     # @raise [RuntimeError] TSS request failed
-    def create_organization(organization_id, meta = {})
-      path = "/v1/organizations/#{organization_id}"
+    def create_organization(meta = {})
+      path = base_path
       response = HttpRetriever.authenticated_post(path, query: { meta: meta })
-
       handle_post_response(response, path)
     end
 
@@ -36,7 +33,6 @@ module TSS
     def get_transactions # rubocop:disable AccessorMethodName
       path = "#{base_path}/transactions"
       response = HttpRetriever.authenticated_get(path)
-
       handle_get_response(response, path, 'transactions')
     end
 

--- a/spec/tss/connector_spec.rb
+++ b/spec/tss/connector_spec.rb
@@ -30,10 +30,10 @@ describe TSS::Connector do
   describe '#get_organization' do
     it 'sends a GET request to /v1/organizations/:oid/' do
       expect(TSS::HttpRetriever).to receive(:get)
-        .with("/v1/organizations/#{oid}", auth_mock)
-        .and_return(mock_success('{"organization":[]}'))
+        .with("/v1/#{oid}", auth_mock)
+        .and_return(mock_success('{"organization":{}}'))
 
-      expect(subject.get_organization).to eq([])
+      expect(subject.get_organization).to eq({})
     end
 
     it 'returns nil if the TSS responds with code 404' do
@@ -62,10 +62,10 @@ describe TSS::Connector do
         basic_auth: an_instance_of(Hash)
       )
       expect(TSS::HttpRetriever).to receive(:post)
-        .with("/v1/organizations/#{fake_id}", options)
+        .with("/v1/#{oid}", options)
         .and_return(mock_created('{}'))
 
-      expect(subject.create_organization(fake_id, 'foo' => 'bar')).to eq({})
+      expect(subject.create_organization('foo' => 'bar')).to eq({})
     end
 
     it 'raises an error if the TSS responds with code != 201' do
@@ -73,7 +73,7 @@ describe TSS::Connector do
         .with(any_args)
         .and_return(mock_server_error)
 
-      expect { subject.create_organization(fake_id) }
+      expect { subject.create_organization(oid) }
         .to raise_error(RuntimeError)
     end
   end


### PR DESCRIPTION
ping @ceigel 

Why? There is a very confusing behaviour since the introduction `#create_organization`. Imagine the following (before the changes from this PR):

```
oid = SecureRandom.uuid
other = SecureRandom.uuid
connector = TSS::Connector.new(oid)
connector.create_organization(other) # => POST /v1/organizations/#{other}
connector.get_organization # => GET /v1/organziations/#{oid}
```

That's **very** confusing and unexpected. This PR fixes the situation as follows:

* Firstly, `#create_organization` uses the `#oid` the connector has been initialized with (instead of the param).
* Secondly (kind of off-topic), I've changed the request paths to not include the segment `organizations`, which allows us to always use the connector's `#base_path`.

Update for the TSS API coming soon...