### PR TITLE
C support for '/v1/organization/:oid'-prefixed routes

### DIFF
--- a/lib/tss/connector.rb
+++ b/lib/tss/connector.rb
@@ -59,7 +59,7 @@ module TSS
     private
 
     def base_path
-      "/v1/#{oid}"
+      "/v1/organizations/#{oid}"
     end
 
     def handle_post_response(response, path)

--- a/spec/tss/connector_spec.rb
+++ b/spec/tss/connector_spec.rb
@@ -30,7 +30,7 @@ describe TSS::Connector do
   describe '#get_organization' do
     it 'sends a GET request to /v1/organizations/:oid/' do
       expect(TSS::HttpRetriever).to receive(:get)
-        .with("/v1/#{oid}", auth_mock)
+        .with("/v1/organizations/#{oid}", auth_mock)
         .and_return(mock_success('{"organization":{}}'))
 
       expect(subject.get_organization).to eq({})
@@ -62,7 +62,7 @@ describe TSS::Connector do
         basic_auth: an_instance_of(Hash)
       )
       expect(TSS::HttpRetriever).to receive(:post)
-        .with("/v1/#{oid}", options)
+        .with("/v1/organizations/#{oid}", options)
         .and_return(mock_created('{}'))
 
       expect(subject.create_organization('foo' => 'bar')).to eq({})
@@ -81,7 +81,7 @@ describe TSS::Connector do
   describe '#get_transactions' do
     it 'sends a GET request to /v1/:oid/transactions' do
       expect(TSS::HttpRetriever).to receive(:get)
-        .with("/v1/#{oid}/transactions", auth_mock)
+        .with("/v1/organizations/#{oid}/transactions", auth_mock)
         .and_return(mock_success('{"transactions":[]}'))
 
       expect(subject.get_transactions).to eq([])
@@ -109,7 +109,7 @@ describe TSS::Connector do
   describe '#get_transaction' do
     it 'sends a GET request to /v1/:oid/transactions/:id' do
       expect(TSS::HttpRetriever).to receive(:get)
-        .with("/v1/#{oid}/transactions/#{fake_id}", auth_mock)
+        .with("/v1/organizations/#{oid}/transactions/#{fake_id}", auth_mock)
         .and_return(mock_success('{"transaction":{}}'))
 
       expect(subject.get_transaction(fake_id)).to eq({})
@@ -138,7 +138,7 @@ describe TSS::Connector do
     it 'sends a POST request to /v1/:oid/bank_accounts' do
       options = hash_including(basic_auth: an_instance_of(Hash))
       expect(TSS::HttpRetriever).to receive(:post)
-        .with("/v1/#{oid}/bank_accounts", options)
+        .with("/v1/organizations/#{oid}/bank_accounts", options)
         .and_return(mock_created('{}'))
 
       expect(subject.add_bank_account(fake_token)).to eq({})


### PR DESCRIPTION
ping @ceigel 

As just discussed.